### PR TITLE
Added generateSignedProxyUrl function.

### DIFF
--- a/apitypes.go
+++ b/apitypes.go
@@ -26,11 +26,26 @@ type SearchResponse struct {
 }
 
 type IconikObject struct {
-	Files []IconikFile `json:"files"`
+	Id      string        `json:"id"`
+	Files   []IconikFile  `json:"files"`
+	Proxies []IconikProxy `json:"proxies"`
+}
+
+type IconikProxy struct {
+	Id string `json:"id"`
 }
 
 type IconikFile struct {
 	Name string `json:"name"`
+}
+
+// ProxyGetUrlSchema is empty. This is because as of 2022Q1, proxies/{proxy_id}
+// calls take no arguments in their body.
+type ProxyGetUrlSchema struct {
+}
+
+type ProxyGetUrlResponse struct {
+	URL string `json:"url"`
 }
 
 // IError encapsulates an error message returned by the Iconik API.

--- a/client_test.go
+++ b/client_test.go
@@ -2,13 +2,14 @@ package iconik
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
 
 func testSendRequest(t *testing.T) {
-	expected := SearchResponse{Objects: []IconikObject{{[]IconikFile{IconikFile{Name: "test"}}}}}
+	expected := SearchResponse{Objects: []IconikObject{{Id: "abc", Files: []IconikFile{IconikFile{Name: "test"}}}}}
 
 	//Start a local HTTP server
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -34,5 +35,36 @@ func testSendRequest(t *testing.T) {
 	}
 	if len(resp.Objects) != len(expected.Objects) {
 		t.Errorf("Got %d objects in response; wanted %d objects", len(resp.Objects), len(expected.Objects))
+	}
+}
+
+func TestIClient_GenerateSignedProxyUrl(t *testing.T) {
+	expected := "https://test.com/url"
+	assetId := "testAssetId"
+	proxyId := "testProxyId"
+
+	//Start a local HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Test request parameters
+		if req.URL.String() == iconikHost+fmt.Sprintf(proxyEndpointTemplate, assetId, proxyId) {
+			payload, _ := json.Marshal(expected)
+			rw.Write(payload)
+		}
+	}))
+
+	// Close the server when test finishes
+	defer server.Close()
+
+	creds := Credentials{
+		AppID: "testAppID",
+		Token: "testToken",
+	}
+	client, _ := NewIClient(creds, "")
+	url, err := client.GenerateSignedProxyUrl(assetId, proxyId)
+	if err != nil {
+		t.Fatalf("GenerateSignedProxyUrl(%s, %s) got %v; wanted no error)", assetId, proxyId, err)
+	}
+	if url != expected {
+		t.Errorf("GenerateSignedProxyUrl(%s, %s) got %s; wanted %s", assetId, proxyId, url, expected)
 	}
 }


### PR DESCRIPTION
This takes an asset + proxyId, and returns the proxy's URL. Each SearchResponse from SearchWithTag gives said (assetID, proxyID) information.